### PR TITLE
Fix reading an existing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This executes `s3cmd ls s3://BUCKET/OBJECT/`, and shows the result as a quickfix
 
 ## Requirement
 
-The [s3cmd](https://github.com/s3tools/s3cmd) cli tool, or a same `get`, `put` and `ls` interfafce cli tool.
+The [s3cmd](https://github.com/s3tools/s3cmd) cli tool, or a same `get --force`
+(overwrites the local file if it already exists), `put` and `ls` interfafce cli
+tool.
 
 ## Option
 
@@ -53,7 +55,10 @@ set runtimepath^=~/.vim/bundle/storage.vim
 
 ## Development
 
-This repository's [spec](https://github.com/blp1526/storage.vim/tree/master/spec) directory has test code. If you want to run test code, open spec file, and exec `source %`.
+This repository's
+[spec](https://github.com/blp1526/storage.vim/tree/master/spec) directory has
+test code. If you want to run test code, open spec file with
+`vim --clean spec/storage_spec.vim`, and exec `source %`.
 
 ## Contributing
 

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -4,6 +4,8 @@ function! storage#read(cmd, path, dict) abort
       if (!has_key(a:dict, a:path))
         let tempfile  = tempname() . '.' . storage#current_file_extension()
         let a:dict[a:path] = tempfile
+      else
+        let tempfile = a:dict[a:path]
       endif
       call storage#get_cmd(a:cmd, a:path, tempfile)
       silent execute 'edit' fnameescape(tempfile)
@@ -101,7 +103,7 @@ function! storage#cmd_script(...) abort
 endfunction
 
 function! storage#get_cmd(cmd, bucket, file) abort
-  let script = storage#cmd_script(a:cmd, 'get', a:bucket, a:file)
+  let script = storage#cmd_script(a:cmd, 'get --force', a:bucket, a:file)
   return storage#run_cmd(script)
 endfunction
 

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -35,9 +35,7 @@ function! storage#write(cmd, dict, path) abort
   silent execute 'normal ggdd'
   silent execute 'write'
   setlocal nobuflisted
-
   echo storage#put_cmd(a:cmd, tempfile, a:path)
-
   silent execute 'edit' fnameescape(a:path)
   setlocal nomodified
   let &hidden = current_hidden

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -34,14 +34,10 @@ function! storage#write(cmd, dict, path) abort
   silent execute 'normal ggdd'
   silent execute 'write'
   setlocal nobuflisted
-  try
-    echo storage#put_cmd(a:cmd, tempfile, a:path)
-  catch
-  finally
-    silent execute 'edit' fnameescape(a:path)
-  endtry
-  " NOTE:
-  " Expected to be still 'modified' if storage#put_cmd failed
+
+  echo storage#put_cmd(a:cmd, tempfile, a:path)
+
+  silent execute 'edit' fnameescape(a:path)
   setlocal nomodified
   let &hidden = current_hidden
 endfunction

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -1,7 +1,7 @@
 function! storage#read(cmd, path, dict) abort
   if (storage#last_string(a:path) !=? '/')
     if (!has_key(a:dict, a:path))
-      let tempfile  = tempname() . '.' . storage#current_file_extension()
+      let tempfile  = tempname()
       let a:dict[a:path] = tempfile
     else
       let tempfile = a:dict[a:path]

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -1,27 +1,24 @@
 function! storage#read(cmd, path, dict) abort
-  try
-    if (storage#last_string(a:path) !=? '/')
-      if (!has_key(a:dict, a:path))
-        let tempfile  = tempname() . '.' . storage#current_file_extension()
-        let a:dict[a:path] = tempfile
-      else
-        let tempfile = a:dict[a:path]
-      endif
-      call storage#get_cmd(a:cmd, a:path, tempfile)
-      silent execute 'edit' fnameescape(tempfile)
-      silent execute '%yank'
-      setlocal nobuflisted
-      silent execute 'edit' fnameescape(a:path)
-      silent execute 'put'
-      silent execute 'normal ggdd'
-      silent execute 'filetype detect'
+  if (storage#last_string(a:path) !=? '/')
+    if (!has_key(a:dict, a:path))
+      let tempfile  = tempname() . '.' . storage#current_file_extension()
+      let a:dict[a:path] = tempfile
     else
-      setlocal nomodified
-      let ls_result = storage#ls_cmd(a:cmd, a:path)
-      call storage#open_quickfix(ls_result)
+      let tempfile = a:dict[a:path]
     endif
-  catch
-  endtry
+    call storage#get_cmd(a:cmd, a:path, tempfile)
+    silent execute 'edit' fnameescape(tempfile)
+    silent execute '%yank'
+    setlocal nobuflisted
+    silent execute 'edit' fnameescape(a:path)
+    silent execute 'put'
+    silent execute 'normal ggdd'
+    silent execute 'filetype detect'
+  else
+    setlocal nomodified
+    let ls_result = storage#ls_cmd(a:cmd, a:path)
+    call storage#open_quickfix(ls_result)
+  endif
 endfunction
 
 function! storage#write(cmd, dict, path) abort
@@ -123,8 +120,7 @@ function! storage#run_cmd(script) abort
   if v:shell_error == 0
     return result
   else
-    echo result
-    throw 'Bad Exit Status Error'
+    throw 'Bad Exit Status Error => ' . trim(result)
   endif
 endfunction
 

--- a/autoload/storage.vim
+++ b/autoload/storage.vim
@@ -14,6 +14,7 @@ function! storage#read(cmd, path, dict) abort
     silent execute 'put'
     silent execute 'normal ggdd'
     silent execute 'filetype detect'
+    setlocal nomodified
   else
     setlocal nomodified
     let ls_result = storage#ls_cmd(a:cmd, a:path)

--- a/spec/storage_spec.vim
+++ b/spec/storage_spec.vim
@@ -33,13 +33,14 @@ function! Spec_storage_read() abort
   let storage_cmd = 's3cmd'
   let file_path = 's3://some-bucket/some-file'
 
+  echo repeat(' ', 2) . 'when called twice for the same file'
   try
     call storage#read(storage_cmd, file_path, storage_dict)
     call storage#read(storage_cmd, file_path, storage_dict)
   catch
     call assert_true(v:exception)
   endtry
-  echo repeat(' ', 2) . 'should not throw an error'
+  echo repeat(' ', 4) . 'should not throw an error'
 
   silent exe 'edit' current_buffer
   silent exe 'bd!' file_path

--- a/spec/storage_spec.vim
+++ b/spec/storage_spec.vim
@@ -2,6 +2,50 @@ source $PWD/autoload/storage.vim
 
 let v:errors = []
 
+" Redefines a function whose name is 'a:name' using 'a:stub'.
+function! Mock_function(name, stub) abort
+  let l:text =<< trim EOF
+    function! %s(...) abort closure
+      return call(a:stub, a:000)
+    endfunction
+  EOF
+  execute printf(join(l:text, "\n"), a:name)
+endfunction
+
+function! Get_stub(cmd, path, tempfile) abort
+  silent execute 'edit' fnameescape(a:tempfile)
+  " Delete the file content.
+  silent execute 'normal! ggdG'
+  silent execute 'normal! a' . 'bla bla' . "\<Esc>"
+  silent execute 'write'
+  setlocal nobuflisted
+endfunction
+
+call Mock_function('storage#get_cmd', funcref('Get_stub'))
+
+" This testing function does not work at first time the script is sourced. The
+" reason is explained in this link:
+" https://stackoverflow.com/a/22633702/747872
+function! Spec_storage_read() abort
+  echo 'storage#read()'
+  let current_buffer = @%
+  let storage_dict = {}
+  let storage_cmd = 's3cmd'
+  let file_path = 's3://some-bucket/some-file'
+
+  try
+    call storage#read(storage_cmd, file_path, storage_dict)
+    call storage#read(storage_cmd, file_path, storage_dict)
+  catch
+    call assert_true(v:exception)
+  endtry
+  echo repeat(' ', 2) . 'should not throw an error'
+
+  silent exe 'edit' current_buffer
+  silent exe 'bd!' file_path
+  echo "\n"
+endfunction
+
 function! Spec_storage_current_file_extension() abort
   echo 'storage#current_file_extension()'
   echo repeat(' ', 2).'when current file is "storage_spec.vim"'
@@ -48,6 +92,7 @@ function! Spec_storage_errorformatted_string() abort
   echo "\n"
 endfunction
 
+call Spec_storage_read()
 call Spec_storage_current_file_extension()
 call Spec_storage_cmd_script()
 call Spec_storage_last_string()

--- a/spec/storage_spec.vim
+++ b/spec/storage_spec.vim
@@ -23,14 +23,11 @@ endfunction
 
 call Mock_function('storage#get_cmd', funcref('Get_stub'))
 
-" This testing function does not work at first time the script is sourced. The
-" reason is explained in this link:
-" https://stackoverflow.com/a/22633702/747872
 function! Spec_storage_read() abort
   echo 'storage#read()'
   let current_buffer = @%
   let storage_dict = {}
-  let storage_cmd = 's3cmd'
+  let storage_cmd = 'whatever'
   let file_path = 's3://some-bucket/some-file'
 
   echo repeat(' ', 2) . 'when called twice for the same file'


### PR DESCRIPTION
Closes #55 

* `try/catch` are removed to give better error information
* in the function `storage#read`, `tempfile` is always defined
* the option `--force` needs to be used when the `tempfile` already exists
    * this could be generalized by defining configurable variables for each command (`get`, `put`, `ls`)
* a test that captures the issue is added

## TODO

- [ ] ~~Improve function mocking in the test (reset mocking)~~